### PR TITLE
feat(diagnose): check services

### DIFF
--- a/pkg/diagnose/diagnose_service.go
+++ b/pkg/diagnose/diagnose_service.go
@@ -1,0 +1,82 @@
+package diagnose
+
+import (
+	"context"
+
+	"github.com/xcoulon/kubectl-diagnose/pkg/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+)
+
+func DiagnoseFromService(logger logr.Logger, cfg *rest.Config, namespace, name string) (bool, error) {
+	svc, err := getService(namespace, name, cfg)
+	if err != nil {
+		return false, err
+	}
+	return checkService(logger, cfg, svc)
+}
+
+func getService(namespace, name string, cfg *rest.Config) (*corev1.Service, error) {
+	cl, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return cl.CoreV1().Services(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+}
+
+func checkService(logger logr.Logger, cfg *rest.Config, svc *corev1.Service) (bool, error) {
+	logger.Infof("👀 checking service '%s' in namespace '%s'...", svc.Name, svc.Namespace)
+	// Check endpoints
+	// endpoints, _ := d.CoreV1().Endpoints(namespace).Get(context.TODO(), name, metav1.GetOptions{})
+
+	// find all pods with the associated label selector in the same namespace
+	selector := labels.Set(svc.Spec.Selector).String()
+	cl, err := kubernetes.NewForConfig(cfg)
+	if err != nil {
+		return false, err
+	}
+	pods, err := cl.CoreV1().Pods(svc.Namespace).List(context.TODO(), metav1.ListOptions{
+		LabelSelector: selector,
+	})
+	if err != nil {
+		return false, err
+	}
+	// if there is no pod matching the selector
+	if len(pods.Items) == 0 {
+		logger.Errorf("👻 no pods matching label selector '%s' found in namespace '%s'", selector, svc.Namespace)
+		logger.Infof("💡 you may want to:")
+		logger.Infof(" - check the 'service.spec.selector' value")
+		logger.Infof(" - make sure that the expected pods exists")
+		return true, nil
+	}
+pods:
+	for _, pod := range pods.Items {
+		for _, sp := range svc.Spec.Ports {
+			logger.Debugf("   checking pod '%s'...", pod.Name)
+			// check the svc/pod port bindings
+		containers:
+			for _, c := range pod.Spec.Containers {
+				for _, cp := range c.Ports {
+					if cp.Name == sp.TargetPort.StrVal || cp.ContainerPort == sp.TargetPort.IntVal {
+						logger.Infof("☑️ found matching target port '%s' (%d) in container '%s' of pod '%s'", cp.Name, cp.ContainerPort, c.Name, pod.Name)
+						break containers
+					}
+				}
+				logger.Errorf("👻 no container with matching target port '%s' in pod '%s'", sp.TargetPort.String(), pod.Name)
+				return true, nil
+			}
+			p := pod
+			if found, err := checkPod(logger, cfg, &p); err != nil {
+				return false, err
+			} else if found {
+				return true, nil
+			}
+			continue pods
+		}
+	}
+
+	return false, nil
+}

--- a/pkg/diagnose/diagnose_service_test.go
+++ b/pkg/diagnose/diagnose_service_test.go
@@ -1,0 +1,76 @@
+package diagnose_test
+
+import (
+	"os"
+
+	"github.com/xcoulon/kubectl-diagnose/pkg/diagnose"
+	"github.com/xcoulon/kubectl-diagnose/pkg/logr"
+	. "github.com/xcoulon/kubectl-diagnose/test"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("diagnose services", func() {
+
+	It("should not detect errors when all good", func() {
+		// given
+		logger := logr.New(os.Stdout)
+		logger.SetLevel(logr.DebugLevel)
+		// TODO: service should have multiple ports
+		apiserver, _, err := NewFakeAPIServer(logger, "resources/all-good.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		cfg := NewConfig(apiserver.URL, "/api")
+
+		// when
+		found, err := diagnose.DiagnoseFromService(logger, cfg, "test", "all-good")
+		// then
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeFalse())
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'all-good' in namespace 'test'...`))
+		Expect(logger.Output()).To(ContainSubstring(`☑️ found matching target port 'http' (8080) in container 'default' of pod 'all-good-785d8bcc5f-g92mn'`))
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking pod 'all-good-785d8bcc5f-g92mn'...`))
+		Expect(logger.Output()).To(ContainSubstring(`☑️ found matching target port 'http' (8080) in container 'default' of pod 'all-good-785d8bcc5f-x85p2'`))
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking pod 'all-good-785d8bcc5f-x85p2'...`))
+	})
+
+	It("should detect no matching pods", func() {
+		// given
+		logger := logr.New(os.Stdout)
+		logger.SetLevel(logr.DebugLevel)
+		apiserver, _, err := NewFakeAPIServer(logger, "resources/service-no-matching-pods.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		cfg := NewConfig(apiserver.URL, "/api")
+
+		// when
+		found, err := diagnose.DiagnoseFromService(logger, cfg, "test", "service-no-matching-pods")
+
+		// then
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'service-no-matching-pods' in namespace 'test'...`))
+		Expect(logger.Output()).To(ContainSubstring(`👻 no pods matching label selector 'app=invalid' found in namespace 'test'`))
+		Expect(logger.Output()).To(ContainSubstring(`💡 you may want to:`))
+		Expect(logger.Output()).To(ContainSubstring(` - check the 'service.spec.selector' value`))
+		Expect(logger.Output()).To(ContainSubstring(` - make sure that the expected pods exists`))
+	})
+
+	It("should detect invalid target port as string", func() {
+		// given
+		logger := logr.New(os.Stdout)
+		logger.SetLevel(logr.DebugLevel)
+		apiserver, _, err := NewFakeAPIServer(logger, "resources/service-invalid-target-port.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		cfg := NewConfig(apiserver.URL, "/api")
+
+		// when
+		found, err := diagnose.DiagnoseFromService(logger, cfg, "test", "service-invalid-target-port")
+
+		// then
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'service-invalid-target-port' in namespace 'test'...`))
+		Expect(logger.Output()).To(ContainSubstring(`👻 no container with matching target port 'https' in pod 'service-invalid-target-port-68968cf979-wtpcp'`))
+	})
+
+})

--- a/test/resources/all-good.yaml
+++ b/test/resources/all-good.yaml
@@ -1,0 +1,113 @@
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+ name: all-good
+ annotations:
+   nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+ rules:
+   - host: all-good.test
+     http:
+       paths:
+         - path: /
+           pathType: Prefix
+           backend:
+             service:
+               name: all-good
+               port:
+                 number: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: test
+  name: all-good
+  labels:
+    app: all-good
+spec:
+  type: NodePort
+  sessionAffinity: None
+  selector:
+    app: all-good
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: all-good
+  name: all-good-785d8bcc5f-g92mn
+  namespace: test
+spec:
+  containers:
+  - image: k8s.gcr.io/echoserver:1.4
+    imagePullPolicy: IfNotPresent
+    name: default
+    ports:
+    - containerPort: 8080
+      name: http
+      protocol: TCP
+  serviceAccount: default
+  serviceAccountName: default
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  - status: "True"
+    type: ContainersReady
+  - status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - image: k8s.gcr.io/echoserver:1.4
+    imageID: docker-pullable://k8s.gcr.io/echoserver@sha256:5d99aa1120524c801bc8c1a7077e8f5ec122ba16b6dda1a5d3826057f67b9bcb
+    lastState: {}
+    name: default
+    ready: true
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2022-10-18T20:33:24Z"
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    app: all-good
+  name: all-good-785d8bcc5f-x85p2
+  namespace: test
+spec:
+  containers:
+  - image: k8s.gcr.io/echoserver:1.4
+    imagePullPolicy: IfNotPresent
+    name: default
+    ports:
+    - containerPort: 8080
+      name: http
+      protocol: TCP
+  serviceAccount: default
+  serviceAccountName: default
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  - status: "True"
+    type: ContainersReady
+  - status: "True"
+    type: PodScheduled
+  containerStatuses:
+  - image: k8s.gcr.io/echoserver:1.4
+    imageID: docker-pullable://k8s.gcr.io/echoserver@sha256:5d99aa1120524c801bc8c1a7077e8f5ec122ba16b6dda1a5d3826057f67b9bcb
+    lastState: {}
+    name: default
+    ready: true
+    restartCount: 0
+    started: true
+    state:
+      running:
+        startedAt: "2022-10-18T20:33:24Z"

--- a/test/resources/service-no-matching-pods.yaml
+++ b/test/resources/service-no-matching-pods.yaml
@@ -1,0 +1,41 @@
+---
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: test
+  name: service-no-matching-pods
+  labels:
+    app: service-no-matching-pods
+spec:
+  type: NodePort
+  sessionAffinity: None
+  selector:
+    app: invalid # will not match any pod
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  namespace: test
+  name: something-else-785d8bcc5f-g92mn
+  labels:
+    app: something-else # not matching the service selector
+spec:
+  containers:
+  - image: k8s.gcr.io/echoserver:1.4
+    imagePullPolicy: IfNotPresent
+    name: default
+    ports:
+    - containerPort: 8080
+      name: http
+      protocol: TCP
+  serviceAccount: default
+  serviceAccountName: default
+status:
+  conditions:
+  - status: "True"
+    type: Ready


### PR DESCRIPTION
checks that there are pods with the matching selector labels,
and that all matching pods have a container port (name or number)
matching the service's target port.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
