### PR TITLE
refactor(test): move fake api-server tests in separate file

### DIFF
--- a/pkg/diagnose/diagnose_pod_test.go
+++ b/pkg/diagnose/diagnose_pod_test.go
@@ -68,7 +68,6 @@ var _ = Describe("diagnose pods", func() {
 	It("should detect readiness probe error", func() {
 		// given
 		logger := logr.New(os.Stdout)
-		logger.SetLevel(logr.DebugLevel)
 		apiserver, _, err := NewFakeAPIServer(logger, "resources/pod-readiness-probe-error.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")

--- a/pkg/diagnose/diagnose_replicaset_test.go
+++ b/pkg/diagnose/diagnose_replicaset_test.go
@@ -16,7 +16,6 @@ var _ = Describe("diagnose replicasets", func() {
 	It("should detect sa not found", func() {
 		// given
 		logger := logr.New(os.Stdout)
-		logger.SetLevel(logr.DebugLevel)
 		apiserver, _, err := NewFakeAPIServer(logger, "resources/replicaset-service-account-not-found.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")

--- a/pkg/diagnose/diagnose_service_test.go
+++ b/pkg/diagnose/diagnose_service_test.go
@@ -16,7 +16,6 @@ var _ = Describe("diagnose services", func() {
 	It("should not detect errors when all good", func() {
 		// given
 		logger := logr.New(os.Stdout)
-		logger.SetLevel(logr.DebugLevel)
 		// TODO: service should have multiple ports
 		apiserver, _, err := NewFakeAPIServer(logger, "resources/all-good.yaml")
 		Expect(err).NotTo(HaveOccurred())
@@ -37,7 +36,6 @@ var _ = Describe("diagnose services", func() {
 	It("should detect no matching pods", func() {
 		// given
 		logger := logr.New(os.Stdout)
-		logger.SetLevel(logr.DebugLevel)
 		apiserver, _, err := NewFakeAPIServer(logger, "resources/service-no-matching-pods.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")
@@ -58,7 +56,6 @@ var _ = Describe("diagnose services", func() {
 	It("should detect invalid target port as string", func() {
 		// given
 		logger := logr.New(os.Stdout)
-		logger.SetLevel(logr.DebugLevel)
 		apiserver, _, err := NewFakeAPIServer(logger, "resources/service-invalid-target-port.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")

--- a/test/fake_api_server.go
+++ b/test/fake_api_server.go
@@ -10,17 +10,13 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
 	"regexp"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	routev1 "github.com/openshift/api/route/v1"
 	"github.com/xcoulon/kubectl-diagnose/pkg/logr"
 	"gopkg.in/yaml.v3"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -205,114 +201,3 @@ func parseObjects(filename string) ([]runtimeclient.Object, error) {
 	}
 	return objs, nil
 }
-
-var _ = Describe("parse resources", func() {
-
-	It("should parse resources", func() {
-		// when
-		objects, err := parseObjects("resources/service-invalid-target-port.yaml")
-		// then
-		Expect(err).NotTo(HaveOccurred())
-		Expect(objects).To(HaveLen(2))
-	})
-})
-
-var _ = DescribeTable("single resource request regexps",
-	func(re *regexp.Regexp, path, namespace, name string) {
-		match := re.MatchString(path)
-		// then
-		Expect(match).To(BeTrue())
-		groups := re.FindStringSubmatch(path)
-		Expect(namespace).To(Equal(groups[re.SubexpIndex("namespace")]))
-		Expect(name).To(Equal(groups[re.SubexpIndex("name")]))
-	},
-	Entry("pod", podRegexp, "/api/v1/namespaces/test/pods/cookie", "test", "cookie"),
-	Entry("service", serviceRegexp, "/api/v1/namespaces/test/services/cookie", "test", "cookie"),
-	Entry("replicatset", replicasetRegexp, "/apis/apps/v1/namespaces/test/replicasets/cookie", "test", "cookie"),
-	Entry("route", routeRegexp, "/apis/route.openshift.io/v1/namespaces/test/routes/cookie", "test", "cookie"),
-)
-
-var _ = DescribeTable("list pods",
-	func(urlStr string, expectedCount int) {
-		objs := []runtimeclient.Object{
-			&corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test",
-					Name:      "pod-1",
-					Labels: map[string]string{
-						"app":  "cookie",
-						"with": "chocolate",
-					},
-				},
-			},
-			&corev1.Pod{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test",
-					Name:      "pod-1",
-					Labels: map[string]string{
-						"app": "cookie",
-					},
-				},
-			},
-		}
-		u, err := url.Parse(urlStr)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(podsRegex.MatchString(u.String())).To(BeTrue())
-		logger := logr.New(os.Stdout)
-		logger.SetLevel(logr.DebugLevel)
-		pods, err := listPods(logger, objs, u)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(pods.Items).To(HaveLen(expectedCount))
-	},
-	Entry("single match", "/api/v1/namespaces/test/pods?labelSelector=with%3Dchocolate", 1),
-	Entry("multiple matches", "/api/v1/namespaces/test/pods?labelSelector=app%3Dcookie", 2),
-	Entry("no match", "/api/v1/namespaces/test/pods?labelSelector=with%3Dnothing", 0),
-)
-
-var _ = DescribeTable("list events",
-	func(urlStr string, expectedCount int) {
-		objs := []runtimeclient.Object{
-			&corev1.Event{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test",
-					Name:      "pod-1-event-1",
-				},
-				InvolvedObject: corev1.ObjectReference{
-					Namespace: "test",
-					Name:      "pod-1",
-				},
-			},
-			&corev1.Event{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test",
-					Name:      "pod-2-event-1",
-				},
-				InvolvedObject: corev1.ObjectReference{
-					Namespace: "test",
-					Name:      "pod-2",
-				},
-			},
-			&corev1.Event{
-				ObjectMeta: v1.ObjectMeta{
-					Namespace: "test",
-					Name:      "pod-2-event-2",
-				},
-				InvolvedObject: corev1.ObjectReference{
-					Namespace: "test",
-					Name:      "pod-2",
-				},
-			},
-		}
-		u, err := url.Parse(urlStr)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(eventsRegex.MatchString(u.String())).To(BeTrue())
-		logger := logr.New(os.Stdout)
-		logger.SetLevel(logr.DebugLevel)
-		pods, err := listEvents(logger, objs, u)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(pods.Items).To(HaveLen(expectedCount))
-	},
-	Entry("single match", "/api/v1/namespaces/test/events?fieldSelector=involvedObject.namespace%3Dtest%2CinvolvedObject.name%3Dpod-1", 1),
-	Entry("multiple matches", "/api/v1/namespaces/test/events?fieldSelector=involvedObject.namespace%3Dtest%2CinvolvedObject.name%3Dpod-2", 2),
-	Entry("no match", "/api/v1/namespaces/test/events?fieldSelector=involvedObject.namespace%3Dtest%2CinvolvedObject.name%3Dunknown", 0),
-)

--- a/test/fake_api_server_test.go
+++ b/test/fake_api_server_test.go
@@ -1,0 +1,123 @@
+package test
+
+import (
+	"net/url"
+	"os"
+	"regexp"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/xcoulon/kubectl-diagnose/pkg/logr"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	runtimeclient "sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var _ = Describe("parse resources", func() {
+
+	It("should parse resources", func() {
+		// when
+		objects, err := parseObjects("resources/service-invalid-target-port.yaml")
+		// then
+		Expect(err).NotTo(HaveOccurred())
+		Expect(objects).To(HaveLen(2))
+	})
+})
+
+var _ = DescribeTable("single resource request regexps",
+	func(re *regexp.Regexp, path, namespace, name string) {
+		match := re.MatchString(path)
+		// then
+		Expect(match).To(BeTrue())
+		groups := re.FindStringSubmatch(path)
+		Expect(namespace).To(Equal(groups[re.SubexpIndex("namespace")]))
+		Expect(name).To(Equal(groups[re.SubexpIndex("name")]))
+	},
+	Entry("pod", podRegexp, "/api/v1/namespaces/test/pods/cookie", "test", "cookie"),
+	Entry("service", serviceRegexp, "/api/v1/namespaces/test/services/cookie", "test", "cookie"),
+	Entry("replicatset", replicasetRegexp, "/apis/apps/v1/namespaces/test/replicasets/cookie", "test", "cookie"),
+	Entry("route", routeRegexp, "/apis/route.openshift.io/v1/namespaces/test/routes/cookie", "test", "cookie"),
+)
+
+var _ = DescribeTable("list pods",
+	func(urlStr string, expectedCount int) {
+		objs := []runtimeclient.Object{
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "pod-1",
+					Labels: map[string]string{
+						"app":  "cookie",
+						"with": "chocolate",
+					},
+				},
+			},
+			&corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "pod-1",
+					Labels: map[string]string{
+						"app": "cookie",
+					},
+				},
+			},
+		}
+		u, err := url.Parse(urlStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(podsRegex.MatchString(u.String())).To(BeTrue())
+		logger := logr.New(os.Stdout)
+		pods, err := listPods(logger, objs, u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pods.Items).To(HaveLen(expectedCount))
+	},
+	Entry("single match", "/api/v1/namespaces/test/pods?labelSelector=with%3Dchocolate", 1),
+	Entry("multiple matches", "/api/v1/namespaces/test/pods?labelSelector=app%3Dcookie", 2),
+	Entry("no match", "/api/v1/namespaces/test/pods?labelSelector=with%3Dnothing", 0),
+)
+
+var _ = DescribeTable("list events",
+	func(urlStr string, expectedCount int) {
+		objs := []runtimeclient.Object{
+			&corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "pod-1-event-1",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Namespace: "test",
+					Name:      "pod-1",
+				},
+			},
+			&corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "pod-2-event-1",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Namespace: "test",
+					Name:      "pod-2",
+				},
+			},
+			&corev1.Event{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "test",
+					Name:      "pod-2-event-2",
+				},
+				InvolvedObject: corev1.ObjectReference{
+					Namespace: "test",
+					Name:      "pod-2",
+				},
+			},
+		}
+		u, err := url.Parse(urlStr)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(eventsRegex.MatchString(u.String())).To(BeTrue())
+		logger := logr.New(os.Stdout)
+		pods, err := listEvents(logger, objs, u)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(pods.Items).To(HaveLen(expectedCount))
+	},
+	Entry("single match", "/api/v1/namespaces/test/events?fieldSelector=involvedObject.namespace%3Dtest%2CinvolvedObject.name%3Dpod-1", 1),
+	Entry("multiple matches", "/api/v1/namespaces/test/events?fieldSelector=involvedObject.namespace%3Dtest%2CinvolvedObject.name%3Dpod-2", 2),
+	Entry("no match", "/api/v1/namespaces/test/events?fieldSelector=involvedObject.namespace%3Dtest%2CinvolvedObject.name%3Dunknown", 0),
+)


### PR DESCRIPTION
also, remove all calls to `logger.SetLevel(logr.DebugLevel)`

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
