### PR TITLE
refactor(test): implicit 'default' namespace

### DIFF
--- a/pkg/diagnose/diagnose_pod.go
+++ b/pkg/diagnose/diagnose_pod.go
@@ -71,7 +71,7 @@ func checkPodEvents(logger logr.Logger, cfg *rest.Config, pod *corev1.Pod) (bool
 		return false, err
 	}
 	events, err := cl.CoreV1().Events(pod.Namespace).List(context.TODO(), metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("involvedObject.namespace=%s,involvedObject.name=%s", pod.Namespace, pod.Name),
+		FieldSelector: fmt.Sprintf("involvedObject.name=%s", pod.Name),
 	})
 	if err != nil {
 		return false, err

--- a/pkg/diagnose/diagnose_pod_test.go
+++ b/pkg/diagnose/diagnose_pod_test.go
@@ -24,7 +24,7 @@ var _ = Describe("diagnose pods", func() {
 		cfg := NewConfig(apiserver.URL, "/api")
 
 		// when
-		found, err := diagnose.DiagnoseFromPod(logger, cfg, "test", "image-pull-backoff")
+		found, err := diagnose.DiagnoseFromPod(logger, cfg, "default", "image-pull-backoff")
 
 		// then
 		Expect(err).NotTo(HaveOccurred())
@@ -40,7 +40,7 @@ var _ = Describe("diagnose pods", func() {
 		cfg := NewConfig(apiserver.URL, "/api")
 
 		// when
-		found, err := diagnose.DiagnoseFromPod(logger, cfg, "test", "container-config-error")
+		found, err := diagnose.DiagnoseFromPod(logger, cfg, "default", "container-config-error")
 
 		// then
 		Expect(err).NotTo(HaveOccurred())
@@ -56,7 +56,7 @@ var _ = Describe("diagnose pods", func() {
 		cfg := NewConfig(apiserver.URL, "/api")
 
 		// when
-		found, err := diagnose.DiagnoseFromPod(logger, cfg, "test", "unknown-configmap")
+		found, err := diagnose.DiagnoseFromPod(logger, cfg, "default", "unknown-configmap")
 
 		// then
 		Expect(err).NotTo(HaveOccurred())
@@ -73,7 +73,7 @@ var _ = Describe("diagnose pods", func() {
 		cfg := NewConfig(apiserver.URL, "/api")
 
 		// when
-		found, err := diagnose.DiagnoseFromPod(logger, cfg, "test", "readiness-probe-error")
+		found, err := diagnose.DiagnoseFromPod(logger, cfg, "default", "readiness-probe-error")
 
 		// then
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/diagnose/diagnose_replicaset_test.go
+++ b/pkg/diagnose/diagnose_replicaset_test.go
@@ -21,7 +21,7 @@ var _ = Describe("diagnose replicasets", func() {
 		cfg := NewConfig(apiserver.URL, "/api")
 
 		// when
-		found, err := diagnose.DiagnoseFromReplicaSet(logger, cfg, "test", "sa-notfound")
+		found, err := diagnose.DiagnoseFromReplicaSet(logger, cfg, "default", "sa-notfound")
 
 		// then
 		Expect(err).NotTo(HaveOccurred())

--- a/pkg/diagnose/diagnose_service_test.go
+++ b/pkg/diagnose/diagnose_service_test.go
@@ -22,11 +22,11 @@ var _ = Describe("diagnose services", func() {
 		cfg := NewConfig(apiserver.URL, "/api")
 
 		// when
-		found, err := diagnose.DiagnoseFromService(logger, cfg, "test", "all-good")
+		found, err := diagnose.DiagnoseFromService(logger, cfg, "default", "all-good")
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeFalse())
-		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'all-good' in namespace 'test'...`))
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'all-good' in namespace 'default'...`))
 		Expect(logger.Output()).To(ContainSubstring(`☑️ found matching target port 'http' (8080) in container 'default' of pod 'all-good-785d8bcc5f-g92mn'`))
 		Expect(logger.Output()).To(ContainSubstring(`👀 checking pod 'all-good-785d8bcc5f-g92mn'...`))
 		Expect(logger.Output()).To(ContainSubstring(`☑️ found matching target port 'http' (8080) in container 'default' of pod 'all-good-785d8bcc5f-x85p2'`))
@@ -41,13 +41,13 @@ var _ = Describe("diagnose services", func() {
 		cfg := NewConfig(apiserver.URL, "/api")
 
 		// when
-		found, err := diagnose.DiagnoseFromService(logger, cfg, "test", "service-no-matching-pods")
+		found, err := diagnose.DiagnoseFromService(logger, cfg, "default", "service-no-matching-pods")
 
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'service-no-matching-pods' in namespace 'test'...`))
-		Expect(logger.Output()).To(ContainSubstring(`👻 no pods matching label selector 'app=invalid' found in namespace 'test'`))
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'service-no-matching-pods' in namespace 'default'...`))
+		Expect(logger.Output()).To(ContainSubstring(`👻 no pods matching label selector 'app=invalid' found in namespace 'default'`))
 		Expect(logger.Output()).To(ContainSubstring(`💡 you may want to:`))
 		Expect(logger.Output()).To(ContainSubstring(` - check the 'service.spec.selector' value`))
 		Expect(logger.Output()).To(ContainSubstring(` - make sure that the expected pods exists`))
@@ -61,12 +61,12 @@ var _ = Describe("diagnose services", func() {
 		cfg := NewConfig(apiserver.URL, "/api")
 
 		// when
-		found, err := diagnose.DiagnoseFromService(logger, cfg, "test", "service-invalid-target-port")
+		found, err := diagnose.DiagnoseFromService(logger, cfg, "default", "service-invalid-target-port")
 
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'service-invalid-target-port' in namespace 'test'...`))
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'service-invalid-target-port' in namespace 'default'...`))
 		Expect(logger.Output()).To(ContainSubstring(`👻 no container with matching target port 'https' in pod 'service-invalid-target-port-68968cf979-wtpcp'`))
 	})
 

--- a/test/fake_api_server.go
+++ b/test/fake_api_server.go
@@ -196,6 +196,8 @@ func parseObjects(filename string) ([]runtimeclient.Object, error) {
 			return nil, err
 		}
 		if obj, ok := obj.(runtimeclient.Object); ok {
+			// force namespace to `default` here (so it works out-of-the-box on a vanilla Kubernetes cluster)
+			obj.SetNamespace("default")
 			objs = append(objs, obj)
 		}
 	}

--- a/test/fake_api_server_test.go
+++ b/test/fake_api_server_test.go
@@ -21,6 +21,21 @@ var _ = Describe("parse resources", func() {
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(objects).To(HaveLen(2))
+		for _, obj := range objects {
+			Expect(obj.GetNamespace()).To(Equal("default"))
+		}
+	})
+})
+
+var _ = Describe("retrieve logs", func() {
+
+	It("should return logs", func() {
+		// given
+
+		// when
+
+		// then
+
 	})
 })
 

--- a/test/resources/all-good.yaml
+++ b/test/resources/all-good.yaml
@@ -21,11 +21,10 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: test
   name: all-good
   labels:
     app: all-good
-spec:
+spec: 
   type: NodePort
   sessionAffinity: None
   selector:

--- a/test/resources/pod-container-config-error.yaml
+++ b/test/resources/pod-container-config-error.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: test
   name: container-config-error
 spec:
   containers:

--- a/test/resources/pod-image-pull-backoff.yaml
+++ b/test/resources/pod-image-pull-backoff.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: test
   name: image-pull-backoff
 spec:
   containers:

--- a/test/resources/pod-readiness-probe-error.yaml
+++ b/test/resources/pod-readiness-probe-error.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: test
   name: readiness-probe-error
 spec:
   containers:
@@ -38,14 +37,13 @@ status:
     started: true
     state:
       running:
-        startedAt: "2022-10-21T17:18:02Z"
+        startedAt: "2022-10-22T17:18:02Z"
 ---
 apiVersion: v1
 kind: Event
 metadata:
   name: readiness-probe-error.17202520760a2a72
-  namespace: test
-firstTimestamp: "2022-10-21T17:18:03Z"
+firstTimestamp: "2022-10-22T17:18:03Z"
 lastTimestamp: "2022-10-22T08:48:17Z"
 type: Warning
 reason: Unhealthy
@@ -55,5 +53,4 @@ involvedObject:
   apiVersion: v1
   kind: Pod
   name: readiness-probe-error
-  namespace: test
 count: 156

--- a/test/resources/pod-unknown-configmap.yaml
+++ b/test/resources/pod-unknown-configmap.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: test
   name: unknown-configmap
 spec:
   containers:

--- a/test/resources/pod-unknown-volume.yaml
+++ b/test/resources/pod-unknown-volume.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: test
   name: unknown-volume
 spec:
   containers:

--- a/test/resources/replicaset-service-account-not-found.yaml
+++ b/test/resources/replicaset-service-account-not-found.yaml
@@ -1,7 +1,6 @@
 apiVersion: apps/v1
 kind: ReplicaSet
 metadata:
-  namespace: test
   name: sa-notfound
 spec:
   replicas: 1

--- a/test/resources/service-invalid-target-port.yaml
+++ b/test/resources/service-invalid-target-port.yaml
@@ -1,7 +1,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: test
   name: service-invalid-target-port
   labels:
     app: service-invalid-target-port
@@ -19,7 +18,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: test
   name: service-invalid-target-port-68968cf979-wtpcp
   labels:
     app: service-invalid-target-port

--- a/test/resources/service-no-matching-pods.yaml
+++ b/test/resources/service-no-matching-pods.yaml
@@ -2,7 +2,6 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: test
   name: service-no-matching-pods
   labels:
     app: service-no-matching-pods
@@ -20,7 +19,6 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  namespace: test
   name: something-else-785d8bcc5f-g92mn
   labels:
     app: something-else # not matching the service selector


### PR DESCRIPTION
namespace is not specified in the manifests but assumed as `default`
when objects are parsed and loaded in the fake api-server.
(hence, when applying on a real cluster, the current namespace is used)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
