### PR TITLE
refactor(test): use 'httprouter' in fake api-server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/fatih/color v1.9.0
+	github.com/julienschmidt/httprouter v1.3.0
 	github.com/onsi/ginkgo/v2 v2.3.1
 	github.com/onsi/gomega v1.22.0
 	github.com/openshift/api v0.0.0-20220912162045-8cfbc78b21bd

--- a/go.sum
+++ b/go.sum
@@ -301,6 +301,7 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jstemmer/go-junit-report v0.9.1/go.mod h1:Brl9GWCQeLvo8nXZwPNNblvFj/XSXhF0NWZEnDohbsk=
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/julienschmidt/httprouter v1.3.0 h1:U0609e9tgbseu3rBINet9P48AI/D3oJs4dN7jwJOQ1U=
 github.com/julienschmidt/httprouter v1.3.0/go.mod h1:JR6WtHb+2LUe8TCKY3cZOxFyyO8IZAc4RVcycCCAKdM=
 github.com/kisielk/errcheck v1.1.0/go.mod h1:EZBBE59ingxPouuu3KfxchcWSUPOHkagtvWXihfKN4Q=
 github.com/kisielk/errcheck v1.2.0/go.mod h1:/BMXB+zMLi60iA8Vv6Ksmxu/1UDYcXs4uQLJ+jE2L00=

--- a/pkg/diagnose/diagnose_pod_test.go
+++ b/pkg/diagnose/diagnose_pod_test.go
@@ -19,7 +19,7 @@ var _ = Describe("diagnose pods", func() {
 	It("should detect image pull backoff", func() {
 		// given
 		logger := logr.New(io.Discard)
-		apiserver, _, err := NewFakeAPIServer(logger, "resources/pod-image-pull-backoff.yaml")
+		apiserver, err := NewFakeAPIServer(logger, "resources/pod-image-pull-backoff.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")
 
@@ -35,7 +35,7 @@ var _ = Describe("diagnose pods", func() {
 	It("should detect configuration error", func() {
 		// given
 		logger := logr.New(io.Discard)
-		apiserver, _, err := NewFakeAPIServer(logger, "resources/pod-container-config-error.yaml")
+		apiserver, err := NewFakeAPIServer(logger, "resources/pod-container-config-error.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")
 
@@ -51,7 +51,7 @@ var _ = Describe("diagnose pods", func() {
 	It("should detect configmap mount error", func() {
 		// given
 		logger := logr.New(io.Discard)
-		apiserver, _, err := NewFakeAPIServer(logger, "resources/pod-unknown-configmap.yaml")
+		apiserver, err := NewFakeAPIServer(logger, "resources/pod-unknown-configmap.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")
 
@@ -68,7 +68,7 @@ var _ = Describe("diagnose pods", func() {
 	It("should detect readiness probe error", func() {
 		// given
 		logger := logr.New(os.Stdout)
-		apiserver, _, err := NewFakeAPIServer(logger, "resources/pod-readiness-probe-error.yaml")
+		apiserver, err := NewFakeAPIServer(logger, "resources/pod-readiness-probe-error.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")
 

--- a/pkg/diagnose/diagnose_replicaset_test.go
+++ b/pkg/diagnose/diagnose_replicaset_test.go
@@ -16,7 +16,7 @@ var _ = Describe("diagnose replicasets", func() {
 	It("should detect sa not found", func() {
 		// given
 		logger := logr.New(os.Stdout)
-		apiserver, _, err := NewFakeAPIServer(logger, "resources/replicaset-service-account-not-found.yaml")
+		apiserver, err := NewFakeAPIServer(logger, "resources/replicaset-service-account-not-found.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")
 

--- a/pkg/diagnose/diagnose_service_test.go
+++ b/pkg/diagnose/diagnose_service_test.go
@@ -17,7 +17,7 @@ var _ = Describe("diagnose services", func() {
 		// given
 		logger := logr.New(os.Stdout)
 		// TODO: service should have multiple ports
-		apiserver, _, err := NewFakeAPIServer(logger, "resources/all-good.yaml")
+		apiserver, err := NewFakeAPIServer(logger, "resources/all-good.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")
 
@@ -36,7 +36,7 @@ var _ = Describe("diagnose services", func() {
 	It("should detect no matching pods", func() {
 		// given
 		logger := logr.New(os.Stdout)
-		apiserver, _, err := NewFakeAPIServer(logger, "resources/service-no-matching-pods.yaml")
+		apiserver, err := NewFakeAPIServer(logger, "resources/service-no-matching-pods.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")
 
@@ -56,7 +56,7 @@ var _ = Describe("diagnose services", func() {
 	It("should detect invalid target port as string", func() {
 		// given
 		logger := logr.New(os.Stdout)
-		apiserver, _, err := NewFakeAPIServer(logger, "resources/service-invalid-target-port.yaml")
+		apiserver, err := NewFakeAPIServer(logger, "resources/service-invalid-target-port.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")
 

--- a/test/resources/all-good.yaml
+++ b/test/resources/all-good.yaml
@@ -1,22 +1,22 @@
----
-apiVersion: networking.k8s.io/v1
-kind: Ingress
+apiVersion: route.openshift.io/v1
+kind: Route
 metadata:
- name: all-good
- annotations:
-   nginx.ingress.kubernetes.io/rewrite-target: /$1
+  name: all-good
 spec:
- rules:
-   - host: all-good.test
-     http:
-       paths:
-         - path: /
-           pathType: Prefix
-           backend:
-             service:
-               name: all-good
-               port:
-                 number: 8080
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: all-good
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress:
+  - conditions:
+    - status: "True"
+      type: Admitted
+    routerName: default
+    wildcardPolicy: None
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
avoid complexity of regexps to handle and displatch incoming requests
also, use Gomega to test the response headers and body

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
