### PR TITLE
feat(fake-api-server): returns container logs

### DIFF
--- a/test/resources/all-good.logs
+++ b/test/resources/all-good.logs
@@ -1,0 +1,8 @@
+all-good-785d8bcc5f-g92mn:
+  default: |-
+    some
+    logs
+all-good-785d8bcc5f-x85p2:
+  default: |-
+    other
+    logs

--- a/test/resources/all-good.yaml
+++ b/test/resources/all-good.yaml
@@ -41,7 +41,6 @@ metadata:
   labels:
     app: all-good
   name: all-good-785d8bcc5f-g92mn
-  namespace: test
 spec:
   containers:
   - image: k8s.gcr.io/echoserver:1.4
@@ -79,7 +78,6 @@ metadata:
   labels:
     app: all-good
   name: all-good-785d8bcc5f-x85p2
-  namespace: test
 spec:
   containers:
   - image: k8s.gcr.io/echoserver:1.4

--- a/test/resources/pod-container-config-error.logs
+++ b/test/resources/pod-container-config-error.logs
@@ -1,0 +1,4 @@
+container-config-error:
+  default: |-
+    2022/10/25 20:11:45 [emerg] 1#1: mkdir() "/var/lib/nginx/proxy" failed (13: Permission denied)
+    nginx: [emerg] mkdir() "/var/lib/nginx/proxy" failed (13: Permission denied)


### PR DESCRIPTION
read logs from `.logs` files, store in map indexed by pod/container
abnd return when matching request is received

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
