### PR TITLE
feat(diagnose): check ReplicaSet when no Pod matching Service labels

### DIFF
--- a/pkg/diagnose/diagnose_replicaset.go
+++ b/pkg/diagnose/diagnose_replicaset.go
@@ -22,7 +22,7 @@ func getReplicaSet(cfg *rest.Config, namespace, name string) (*appsv1.ReplicaSet
 }
 
 func checkReplicaSet(logger logr.Logger, rs *appsv1.ReplicaSet) (bool, error) {
-	logger.Infof("👀 checking ReplicaSet '%s'...", rs.Name)
+	logger.Infof("👀 checking replicaset '%s'...", rs.Name)
 	return checkReplicaSetStatus(logger, rs)
 }
 

--- a/pkg/diagnose/diagnose_replicaset_test.go
+++ b/pkg/diagnose/diagnose_replicaset_test.go
@@ -13,7 +13,7 @@ import (
 
 var _ = Describe("diagnose replicasets", func() {
 
-	It("should detect sa not found", func() {
+	It("should detect sa not found from replicaset", func() {
 		// given
 		logger := logr.New(io.Discard)
 		apiserver, err := NewFakeAPIServer(logger, "resources/replicaset-service-account-not-found.yaml")
@@ -26,7 +26,24 @@ var _ = Describe("diagnose replicasets", func() {
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		Expect(logger.Output()).To(ContainSubstring(`👀 checking ReplicaSet 'sa-notfound'...`))
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking replicaset 'sa-notfound'...`))
+		Expect(logger.Output()).To(ContainSubstring(`👻 replicaset 'sa-notfound' failed to create pods: pods "sa-notfound-" is forbidden: error looking up service account test/sa-notfound: serviceaccount "sa-notfound" not found`))
+	})
+
+	It("should detect sa not found from route", func() {
+		// given
+		logger := logr.New(io.Discard)
+		apiserver, err := NewFakeAPIServer(logger, "resources/replicaset-service-account-not-found.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		cfg := NewConfig(apiserver.URL, "/api")
+
+		// when
+		found, err := diagnose.Diagnose(logger, cfg, diagnose.Route, "default", "sa-notfound")
+
+		// then
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking replicaset 'sa-notfound'...`))
 		Expect(logger.Output()).To(ContainSubstring(`👻 replicaset 'sa-notfound' failed to create pods: pods "sa-notfound-" is forbidden: error looking up service account test/sa-notfound: serviceaccount "sa-notfound" not found`))
 	})
 

--- a/pkg/diagnose/diagnose_service_test.go
+++ b/pkg/diagnose/diagnose_service_test.go
@@ -48,9 +48,7 @@ var _ = Describe("diagnose services", func() {
 		Expect(found).To(BeTrue())
 		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'service-no-matching-pods' in namespace 'default'...`))
 		Expect(logger.Output()).To(ContainSubstring(`👻 no pods matching label selector 'app=invalid' found in namespace 'default'`))
-		Expect(logger.Output()).To(ContainSubstring(`💡 you may want to:`))
-		Expect(logger.Output()).To(ContainSubstring(` - check the 'service.spec.selector' value`))
-		Expect(logger.Output()).To(ContainSubstring(` - make sure that the expected pods exists`))
+		Expect(logger.Output()).To(ContainSubstring(`💡 you may want to verify that the pods exist and their labels match 'app=invalid'`))
 	})
 
 	It("should detect invalid target port as string", func() {

--- a/test/resources/replicaset-service-account-not-found.yaml
+++ b/test/resources/replicaset-service-account-not-found.yaml
@@ -1,7 +1,47 @@
-apiVersion: apps/v1
-kind: ReplicaSet
+# vscode-kubernetes-tools: exclude
+# (because OpenShift routes seem to be interpreted as pods ¯\_(ツ)_/¯)
+apiVersion: route.openshift.io/v1
+kind: Route
 metadata:
   name: sa-notfound
+spec:
+  port:
+    targetPort: http
+  to:
+    kind: Service
+    name: sa-notfound
+    weight: 100
+  wildcardPolicy: None
+status:
+  ingress:
+  - conditions:
+    - status: "True"
+      type: Admitted
+    routerName: default
+    wildcardPolicy: None
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sa-notfound
+  labels:
+    app: sa-notfound
+spec:
+  type: ClusterIP
+  sessionAffinity: None
+  selector:
+    app: sa-notfound
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: http
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: sa-notfound
+  uid: 8c877af3-a46f-4d40-b83b-c8d143b3cc8a # needed to set OwnerReference in ReplicaSet
 spec:
   replicas: 1
   selector:
@@ -16,6 +56,48 @@ spec:
       - name: default
         image: caddy:2
         imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 500m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
+      serviceAccount: sa-notfound # ServiceAccount does not exist (by default, only `default` exists)
+      serviceAccountName: sa-notfound 
+---
+apiVersion: apps/v1
+kind: ReplicaSet
+metadata:
+  name: sa-notfound
+  ownerReferences:
+  - apiVersion: apps/v1
+    # blockOwnerDeletion: true
+    controller: true
+    kind: Deployment
+    name: sa-notfound
+    uid: 8c877af3-a46f-4d40-b83b-c8d143b3cc8a
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sa-notfound
+  template:
+    metadata:
+      labels:
+        app: sa-notfound
+    spec:
+      containers:
+      - name: default
+        image: caddy:2
+        imagePullPolicy: Always
+        resources:
+          limits:
+            cpu: 500m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 20Mi
       serviceAccount: sa-notfound # ServiceAccount does not exist (by default, only `default` exists)
       serviceAccountName: sa-notfound 
 status:


### PR DESCRIPTION
when there is no Pod matching the Service labels, attempt to lookup the
"parent" ReplicaSet and check its status.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
