### PR TITLE
fix(diagnose): false positive on pod with many containers

### DIFF
--- a/pkg/diagnose/diagnose_service.go
+++ b/pkg/diagnose/diagnose_service.go
@@ -63,17 +63,21 @@ func checkService(logger logr.Logger, cfg *rest.Config, svc *corev1.Service) (bo
 pods:
 	for _, pod := range pods.Items {
 		for _, sp := range svc.Spec.Ports {
-			logger.Debugf("   checking pod '%s'...", pod.Name)
+			logger.Debugf("checking pod '%s'...", pod.Name)
 			// check the svc/pod port bindings
+			found := false
 		containers:
 			for _, c := range pod.Spec.Containers {
 				for _, cp := range c.Ports {
 					if cp.Name == sp.TargetPort.StrVal || cp.ContainerPort == sp.TargetPort.IntVal {
 						logger.Infof("☑️ found matching target port '%s' (%d) in container '%s' of pod '%s'", cp.Name, cp.ContainerPort, c.Name, pod.Name)
+						found = true
 						break containers
 					}
 				}
-				logger.Errorf("👻 no container with matching target port '%s' in pod '%s'", sp.TargetPort.String(), pod.Name)
+			}
+			if !found {
+				logger.Errorf("👻 no container with port '%s' in pod '%s'", sp.TargetPort.String(), pod.Name)
 				return true, nil
 			}
 			p := pod

--- a/pkg/diagnose/diagnose_service_test.go
+++ b/pkg/diagnose/diagnose_service_test.go
@@ -54,18 +54,35 @@ var _ = Describe("diagnose services", func() {
 	It("should detect invalid target port as string", func() {
 		// given
 		logger := logr.New(io.Discard)
-		apiserver, err := NewFakeAPIServer(logger, "resources/service-invalid-target-port.yaml")
+		apiserver, err := NewFakeAPIServer(logger, "resources/service-invalid-target-port-str.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")
 
 		// when
-		found, err := diagnose.Diagnose(logger, cfg, "svc", "default", "service-invalid-target-port")
+		found, err := diagnose.Diagnose(logger, cfg, "svc", "default", "service-invalid-target-port-str")
 
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'service-invalid-target-port' in namespace 'default'...`))
-		Expect(logger.Output()).To(ContainSubstring(`👻 no container with matching target port 'https' in pod 'service-invalid-target-port-68968cf979-wtpcp'`))
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'service-invalid-target-port-str' in namespace 'default'...`))
+		Expect(logger.Output()).To(ContainSubstring(`👻 no container with port 'https' in pod 'service-invalid-target-port-str'`))
+	})
+
+	It("should detect invalid target port as int", func() {
+		// given
+		logger := logr.New(io.Discard)
+		apiserver, err := NewFakeAPIServer(logger, "resources/service-invalid-target-port-int.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		cfg := NewConfig(apiserver.URL, "/api")
+
+		// when
+		found, err := diagnose.Diagnose(logger, cfg, "svc", "default", "service-invalid-target-port-int")
+
+		// then
+		Expect(err).NotTo(HaveOccurred())
+		Expect(found).To(BeTrue())
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'service-invalid-target-port-int' in namespace 'default'...`))
+		Expect(logger.Output()).To(ContainSubstring(`👻 no container with port '8443' in pod 'service-invalid-target-port-int'`))
 	})
 
 })

--- a/test/fake_api_server_test.go
+++ b/test/fake_api_server_test.go
@@ -112,12 +112,12 @@ var _ = Describe("fake api-server endpoints", func() {
 	It("should get single service", func() {
 		// given
 		logger := logr.New(io.Discard)
-		s, err := NewFakeAPIServer(logger, "resources/service-invalid-target-port.yaml")
+		s, err := NewFakeAPIServer(logger, "resources/all-good.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
 
 		// when
-		resp, err := http.DefaultClient.Get(s.URL + "/api/v1/namespaces/default/services/service-invalid-target-port")
+		resp, err := http.DefaultClient.Get(s.URL + "/api/v1/namespaces/default/services/all-good")
 
 		// then
 		Expect(err).NotTo(HaveOccurred())

--- a/test/resources/all-good.yaml
+++ b/test/resources/all-good.yaml
@@ -45,6 +45,25 @@ metadata:
     app: all-good
 spec:
   containers:
+  - name: unused
+    image: caddy:2
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 8079
+      name: unused
+      protocol: TCP
+    resources:
+      limits:
+        cpu: 500m
+        memory: 100Mi
+      requests:
+        cpu: 100m
+        memory: 20Mi
+    volumeMounts:
+    - name: caddy-config
+      mountPath: "/etc/caddy"
+    - name: caddy-config-cache
+      mountPath: "/config/caddy"
   - name: default
     image: caddy:2
     imagePullPolicy: IfNotPresent

--- a/test/resources/service-invalid-target-port-int.yaml
+++ b/test/resources/service-invalid-target-port-int.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: service-invalid-target-port-int
+  labels:
+    app: service-invalid-target-port-int
+spec:
+  type: NodePort
+  sessionAffinity: None
+  selector:
+    app: service-invalid-target-port-int
+  ports:
+  - name: http
+    port: 8080
+    protocol: TCP
+    targetPort: 8443 # invalid target port (`8443` instead of `8080`)
+---
+apiVersion: v1
+kind: Pod
+metadata:
+  name: service-invalid-target-port-int
+  labels:
+    app: service-invalid-target-port-int
+spec:
+  containers:
+  - name: default
+    image: caddy:2
+    imagePullPolicy: IfNotPresent
+    ports:
+    - containerPort: 8080
+      name: http
+      protocol: TCP
+    resources:
+      limits:
+        cpu: 500m
+        memory: 100Mi
+      requests:
+        cpu: 100m
+        memory: 20Mi
+  serviceAccount: default
+  serviceAccountName: default
+status:
+  conditions:
+  - status: "True"
+    type: Ready
+  - status: "True"
+    type: ContainersReady
+  containerStatuses:
+  - containerID: docker://6f075f5f805f50c3649feeb7a49c36aa2086aa526bbf9aefa318d72a31acf1d9
+    image: caddy:2
+    imageID: docker-pullable://k8s.gcr.io/echoserver@sha256:5d99aa1120524c801bc8c1a7077e8f5ec122ba16b6dda1a5d3826057f67b9bcb
+    name: default
+    ready: true
+    started: true
+    restartCount: 0
+    state:
+      running:
+        startedAt: "2022-10-20T05:36:53Z"

--- a/test/resources/service-invalid-target-port-str.yaml
+++ b/test/resources/service-invalid-target-port-str.yaml
@@ -1,14 +1,14 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: service-invalid-target-port
+  name: service-invalid-target-port-str
   labels:
-    app: service-invalid-target-port
+    app: service-invalid-target-port-str
 spec:
   type: NodePort
   sessionAffinity: None
   selector:
-    app: service-invalid-target-port
+    app: service-invalid-target-port-str
   ports:
   - name: http
     port: 8080
@@ -18,9 +18,9 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
-  name: service-invalid-target-port-68968cf979-wtpcp
+  name: service-invalid-target-port-str
   labels:
-    app: service-invalid-target-port
+    app: service-invalid-target-port-str
 spec:
   containers:
   - name: default


### PR DESCRIPTION
avoid false positive when 1 of the containers has a port matching the service's target port

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
