### PR TITLE
fix(diagnose): do not check logs when container did not even start

### DIFF
--- a/pkg/diagnose/diagnose_test.go
+++ b/pkg/diagnose/diagnose_test.go
@@ -33,7 +33,7 @@ var _ = DescribeTable("container in CrashLoopBackOff status",
 		lastTimestamp, _ := time.Parse("2006-01-02T15:04:05Z", "2022-11-12T18:02:28Z")
 		Expect(logger.Output()).To(ContainSubstring(fmt.Sprintf(`⚡️ %s ago: Back-off restarting failed container`, time.Since(lastTimestamp).Truncate(time.Second))))
 		// logs
-		Expect(logger.Output()).To(ContainSubstring(`👀 checking logs in 'default' container...`))
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking 'default' container logs...`))
 		Expect(logger.Output()).To(ContainSubstring(`🗒  Error: loading initial config: loading new config: http app module: start: listening on :80: listen tcp :80: bind: permission denied`))
 	},
 	Entry("should detect from pod", diagnose.Pod, "test", "crash-loop-back-off-7994787459-2nrz5"),
@@ -60,8 +60,6 @@ var _ = DescribeTable("container in ImagePullBackOff status",
 		Expect(logger.Output()).To(ContainSubstring(`👻 container 'default' is waiting with reason 'ImagePullBackOff': Back-off pulling image "unknown:v0.0.0"`))
 		lastTimestamp, _ := time.Parse("2006-01-02T15:04:05Z", "2022-11-13T07:59:04Z")
 		Expect(logger.Output()).To(ContainSubstring(fmt.Sprintf(`⚡️ %s ago: Error: ImagePullBackOff`, time.Since(lastTimestamp).Truncate(time.Second))))
-		Expect(logger.Output()).To(ContainSubstring(`👀 checking logs in 'default' container...`))
-		Expect(logger.Output()).To(ContainSubstring(`🤷 no relevant message found in the pod logs (but you may want to check yourself)`))
 	},
 	Entry("should detect from pod", diagnose.Pod, "test", "image-pull-back-off-9bbb4f9bd-pjj55"),
 	Entry("should detect from replicaset", diagnose.ReplicaSet, "test", "image-pull-back-off-9bbb4f9bd"),
@@ -103,7 +101,7 @@ var _ = DescribeTable("container with readiness probe error",
 	func(kind, namespace, name string) {
 		// given
 		logger := logr.New(io.Discard)
-		apiserver, err := NewFakeAPIServer(logger, "resources/pod-readiness-probe-error.yaml")
+		apiserver, err := NewFakeAPIServer(logger, "resources/pod-readiness-probe-error.yaml", "resources/pod-readiness-probe-error.logs")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := NewConfig(apiserver.URL, "/api")
 
@@ -118,6 +116,9 @@ var _ = DescribeTable("container with readiness probe error",
 		// events
 		lastTimestamp, _ := time.Parse("2006-01-02T15:04:05Z", "2022-11-13T21:55:27Z")
 		Expect(logger.Output()).To(ContainSubstring(fmt.Sprintf(`⚡️ %s ago: Readiness probe failed: HTTP probe failed with statuscode: 404`, time.Since(lastTimestamp).Truncate(time.Second))))
+		// logs
+		Expect(logger.Output()).To(ContainSubstring(`👀 checking 'default' container logs...`))
+		Expect(logger.Output()).To(ContainSubstring("🤷 no 'error'/'fatal'/'panic'/'emerg' messages found in the container logs"))
 	},
 	Entry("should detect from pod", diagnose.Pod, "test", "readiness-probe-error-6cb7664768-qlmns"),
 	Entry("should detect from replicaset", diagnose.ReplicaSet, "test", "readiness-probe-error-6cb7664768"),

--- a/test/resources/pod-crash-loop-back-off.yaml
+++ b/test/resources/pod-crash-loop-back-off.yaml
@@ -249,6 +249,11 @@ status:
     ready: false
     restartCount: 32
     started: false
+    lastState:
+      terminated:
+        containerID: cri-o://535539c2857de6af7128c1b236193408d2d7a0560436f60591ef351a15723690
+        exitCode: 1
+        reason: Error
     state:
       waiting:
         message: back-off 5m0s restarting failed container=default pod=crash-loop-back-off-7994787459-2nrz5(307c7d07-dda4-4877-8195-833e2e7a9e7a)

--- a/test/resources/pod-readiness-probe-error.logs
+++ b/test/resources/pod-readiness-probe-error.logs
@@ -1,0 +1,11 @@
+readiness-probe-error-6cb7664768-qlmns:
+  default: |-
+    {"level":"info","ts":1668791096.6823626,"msg":"using provided configuration","config_file":"/etc/caddy/Caddyfile","config_adapter":"caddyfile"}
+    {"level":"warn","ts":1668791096.6829545,"msg":"Caddyfile input is not formatted; run the 'caddy fmt' command to fix inconsistencies","adapter":"caddyfile","file":"/etc/caddy/Caddyfile","line":3}
+    {"level":"info","ts":1668791096.6845772,"logger":"admin","msg":"admin endpoint started","address":"localhost:2019","enforce_origin":false,"origins":["//localhost:2019","//[::1]:2019","//127.0.0.1:2019"]}
+    {"level":"info","ts":1668791096.6847827,"logger":"tls.cache.maintenance","msg":"started background certificate maintenance","cache":"0xc0006a62a0"}
+    {"level":"info","ts":1668791096.684886,"logger":"tls","msg":"cleaning storage unit","description":"FileStorage:/data/caddy"}
+    {"level":"info","ts":1668791096.6849148,"logger":"http.log","msg":"server running","name":"srv0","protocols":["h1","h2","h3"]}
+    {"level":"info","ts":1668791096.6849515,"logger":"tls","msg":"finished cleaning storage units"}
+    {"level":"info","ts":1668791096.6850195,"msg":"autosaved config (load with --resume flag)","file":"/config/caddy/autosave.json"}
+    {"level":"info","ts":1668791096.6850297,"msg":"serving initial configuration"}


### PR DESCRIPTION
check the `.status.containerStatuses[].lastState` before trying to
get logs, which result in an error if the container has not started
yet, for example in case of an `ImagePullBackOff` error.

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
