### PR TITLE
refactor(diagnose): resource kinds

### DIFF
--- a/pkg/diagnose/diagnose.go
+++ b/pkg/diagnose/diagnose.go
@@ -9,32 +9,32 @@ import (
 )
 
 func Diagnose(logger logr.Logger, cfg *rest.Config, kind, namespace, name string) (bool, error) {
-	switch {
-	case IsRoute(kind):
+	switch Kind(kind) {
+	case Route:
 		r, err := getRoute(cfg, namespace, name)
 		if err != nil {
 			return false, err
 		}
 		return checkRoute(logger, cfg, r)
-	case IsService(kind):
+	case Service:
 		svc, err := getService(cfg, namespace, name)
 		if err != nil {
 			return false, err
 		}
 		return checkService(logger, cfg, svc)
-	case IsDeployment(kind):
+	case Deployment:
 		d, err := getDeployment(cfg, namespace, name)
 		if err != nil {
 			return false, err
 		}
 		return checkDeployment(logger, cfg, d)
-	case IsReplicaSet(kind):
+	case ReplicaSet:
 		rs, err := getReplicaSet(cfg, namespace, name)
 		if err != nil {
 			return false, err
 		}
 		return checkReplicaSet(logger, cfg, rs)
-	case IsPod(kind):
+	case Pod:
 		pod, err := getPod(cfg, namespace, name)
 		if err != nil {
 			return false, err

--- a/pkg/diagnose/diagnose_test.go
+++ b/pkg/diagnose/diagnose_test.go
@@ -27,16 +27,15 @@ var _ = DescribeTable("container in CrashLoopBackOff status",
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		if diagnose.IsRoute(kind) {
+		k := diagnose.Kind(kind)
+		switch {
+		case k == diagnose.Route:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking route 'crash-loop-back-off' in namespace 'test'...`))
-		}
-		if diagnose.IsRoute(kind) || diagnose.IsService(kind) {
+		case k == diagnose.Route || k == diagnose.Service:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'crash-loop-back-off' in namespace 'test'...`))
-		}
-		if diagnose.IsDeployment(kind) {
+		case k == diagnose.Deployment:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking deployment 'crash-loop-back-off' in namespace 'test'...`))
-		}
-		if diagnose.IsDeployment(kind) || diagnose.IsReplicaSet(kind) {
+		case k == diagnose.Deployment || k == diagnose.ReplicaSet:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking replicaset 'crash-loop-back-off-7994787459' in namespace 'test'...`))
 		}
 		// in all cases:
@@ -71,16 +70,15 @@ var _ = DescribeTable("container in ImagePullBackOff status",
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		if diagnose.IsRoute(kind) {
+		k := diagnose.Kind(kind)
+		switch {
+		case k == diagnose.Route:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking route 'image-pull-back-off' in namespace 'test'...`))
-		}
-		if diagnose.IsRoute(kind) || diagnose.IsService(kind) {
+		case k == diagnose.Route || k == diagnose.Service:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'image-pull-back-off' in namespace 'test'...`))
-		}
-		if diagnose.IsDeployment(kind) {
+		case k == diagnose.Deployment:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking deployment 'image-pull-back-off' in namespace 'test'...`))
-		}
-		if diagnose.IsDeployment(kind) || diagnose.IsReplicaSet(kind) {
+		case k == diagnose.Deployment || k == diagnose.ReplicaSet:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking replicaset 'image-pull-back-off-9bbb4f9bd' in namespace 'test'...`))
 		}
 		// in all cases:
@@ -110,16 +108,15 @@ var _ = DescribeTable("container with unknown configmap mount",
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		if diagnose.IsRoute(kind) {
+		k := diagnose.Kind(kind)
+		switch {
+		case k == diagnose.Route:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking route 'unknown-configmap' in namespace 'test'...`))
-		}
-		if diagnose.IsRoute(kind) || diagnose.IsService(kind) {
+		case k == diagnose.Route || k == diagnose.Service:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'unknown-configmap' in namespace 'test'...`))
-		}
-		if diagnose.IsDeployment(kind) {
+		case k == diagnose.Deployment:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking deployment 'unknown-configmap' in namespace 'test'...`))
-		}
-		if diagnose.IsDeployment(kind) || diagnose.IsReplicaSet(kind) {
+		case k == diagnose.Deployment || k == diagnose.ReplicaSet:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking replicaset 'unknown-configmap-76476b7d5' in namespace 'test'...`))
 		}
 		// in all cases:
@@ -154,16 +151,15 @@ var _ = DescribeTable("container with readiness probe error",
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		if diagnose.IsRoute(kind) {
+		k := diagnose.Kind(kind)
+		switch {
+		case k == diagnose.Route:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking route 'readiness-probe-error' in namespace 'test'...`))
-		}
-		if diagnose.IsRoute(kind) || diagnose.IsService(kind) {
+		case k == diagnose.Route || k == diagnose.Service:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'readiness-probe-error' in namespace 'test'...`))
-		}
-		if diagnose.IsDeployment(kind) {
+		case k == diagnose.Deployment:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking deployment 'readiness-probe-error' in namespace 'test'...`))
-		}
-		if diagnose.IsDeployment(kind) || diagnose.IsReplicaSet(kind) {
+		case k == diagnose.Deployment || k == diagnose.ReplicaSet:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking replicaset 'readiness-probe-error-6cb7664768' in namespace 'test'...`))
 		}
 		// in all cases:
@@ -197,13 +193,13 @@ var _ = DescribeTable("serviceaccount not found",
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		if diagnose.IsRoute(kind) {
+		k := diagnose.Kind(kind)
+		switch {
+		case k == diagnose.Route:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking route 'sa-notfound' in namespace 'test'...`))
-		}
-		if diagnose.IsRoute(kind) || diagnose.IsService(kind) {
+		case k == diagnose.Route || k == diagnose.Service:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'sa-notfound' in namespace 'test'...`))
-		}
-		if diagnose.IsDeployment(kind) {
+		case k == diagnose.Deployment:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking deployment 'sa-notfound' in namespace 'test'...`))
 		}
 		// in all cases:
@@ -230,7 +226,7 @@ var _ = DescribeTable("should detect no matching pods",
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		if diagnose.IsRoute(kind) {
+		if diagnose.Kind(kind) == diagnose.Route {
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking route 'no-matching-pods' in namespace 'test'...`))
 		}
 		// in all cases:
@@ -256,7 +252,7 @@ var _ = DescribeTable("should detect invalid service target port as string",
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		if diagnose.IsRoute(kind) {
+		if diagnose.Kind(kind) == diagnose.Route {
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking route 'invalid-service-target-port-str' in namespace 'test'...`))
 		}
 		// in all cases:
@@ -281,7 +277,7 @@ var _ = DescribeTable("should detect invalid service target port as int",
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		if diagnose.IsRoute(kind) {
+		if diagnose.Kind(kind) == diagnose.Route {
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking route 'invalid-service-target-port-int' in namespace 'test'...`))
 		}
 		// in all cases:
@@ -366,13 +362,14 @@ var _ = DescribeTable("should detect zero replicas specified in deployment",
 		// then
 		Expect(err).NotTo(HaveOccurred())
 		Expect(found).To(BeTrue())
-		if diagnose.IsRoute(kind) {
+		k := diagnose.Kind(kind)
+		switch {
+		case k == diagnose.Route:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking route 'zero-replica' in namespace 'test'...`))
-		}
-		if diagnose.IsRoute(kind) || diagnose.IsService(kind) {
+		case k == diagnose.Route || k == diagnose.Service:
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking service 'zero-replica' in namespace 'test'...`))
 		}
-		if diagnose.IsRoute(kind) || diagnose.IsService(kind) || diagnose.IsReplicaSet(kind) {
+		if k == diagnose.Route || k == diagnose.Service || k == diagnose.ReplicaSet {
 			Expect(logger.Output()).To(ContainSubstring(`👀 checking replicaset 'zero-replica-9bccf7d88' in namespace 'test'...`))
 		}
 		// in all cases

--- a/pkg/diagnose/resource_kind.go
+++ b/pkg/diagnose/resource_kind.go
@@ -1,46 +1,36 @@
 package diagnose
 
-func IsRoute(kind string) bool {
+const (
+	Route = iota
+	Service
+	Deployment
+	ReplicaSet
+	Pod
+	StatefulSet
+	PersistentVolumeClaim
+	StorageClass
+	Unkwown
+)
+
+func Kind(kind string) int {
 	switch kind {
 	case "routes", "route", "route.route.openshift.io":
-		return true
-	default:
-		return false
-	}
-}
-
-func IsService(kind string) bool {
-	switch kind {
+		return Route
 	case "services", "service", "svc":
-		return true
-	default:
-		return false
-	}
-}
-
-func IsDeployment(kind string) bool {
-	switch kind {
+		return Service
 	case "deployments", "deployment", "deploy", "deployment.apps":
-		return true
-	default:
-		return false
-	}
-}
-
-func IsReplicaSet(kind string) bool {
-	switch kind {
+		return Deployment
 	case "replicasets", "replicaset", "rs", "replicaset.apps":
-		return true
-	default:
-		return false
-	}
-}
-
-func IsPod(kind string) bool {
-	switch kind {
+		return ReplicaSet
 	case "pods", "pod", "po":
-		return true
+		return Pod
+	case "statefulsets", "statefulset", "sts", "statefulset.apps":
+		return StatefulSet
+	case "persistentvolumeclaims", "persistentvolumeclaim", "pvc":
+		return PersistentVolumeClaim
+	case "storageclasses", "storageclass", "sc", "storageclass.storage.k8s.io":
+		return StorageClass
 	default:
-		return false
+		return Unkwown
 	}
 }

--- a/pkg/diagnose/resource_kind_test.go
+++ b/pkg/diagnose/resource_kind_test.go
@@ -7,54 +7,53 @@ import (
 	. "github.com/onsi/gomega"
 )
 
-var _ = DescribeTable("route kind",
-	func(kind string, expected bool) {
-		Expect(diagnose.IsRoute(kind)).To(Equal(expected))
+var _ = DescribeTable("resource kind",
+	func(kind string, expected int) {
+		Expect(diagnose.Kind(kind)).To(Equal(expected))
 	},
-	Entry("route", "route", true),
-	Entry("routes", "routes", true),
-	Entry("route.route.openshift.io", "route.route.openshift.io", true),
-	Entry("other", "other", false),
-)
+	// routes
+	Entry("routes", "routes", diagnose.Route),
+	Entry("route", "route", diagnose.Route),
+	Entry("route.route.openshift.io", "route.route.openshift.io", diagnose.Route),
 
-var _ = DescribeTable("service kind",
-	func(kind string, expected bool) {
-		Expect(diagnose.IsService(kind)).To(Equal(expected))
-	},
-	Entry("service", "service", true),
-	Entry("services", "services", true),
-	Entry("svc", "svc", true),
-	Entry("other", "other", false),
-)
+	// services
+	Entry("services", "services", diagnose.Service),
+	Entry("service", "service", diagnose.Service),
+	Entry("svc", "svc", diagnose.Service),
 
-var _ = DescribeTable("replicaset kind",
-	func(kind string, expected bool) {
-		Expect(diagnose.IsReplicaSet(kind)).To(Equal(expected))
-	},
-	Entry("replicaset", "replicaset", true),
-	Entry("replicasets", "replicasets", true),
-	Entry("replicaset", "rs", true),
-	Entry("replicaset.apps", "replicaset.apps", true),
-	Entry("other", "other", false),
-)
+	// replicasets
+	Entry("replicasets", "replicasets", diagnose.ReplicaSet),
+	Entry("replicaset", "replicaset", diagnose.ReplicaSet),
+	Entry("rs", "rs", diagnose.ReplicaSet),
+	Entry("replicaset.apps", "replicaset.apps", diagnose.ReplicaSet),
 
-var _ = DescribeTable("deployment kind",
-	func(kind string, expected bool) {
-		Expect(diagnose.IsDeployment(kind)).To(Equal(expected))
-	},
-	Entry("replicaset", "deployment", true),
-	Entry("deployments", "deployments", true),
-	Entry("deploy", "deploy", true),
-	Entry("deployment.apps", "deployment.apps", true),
-	Entry("other", "other", false),
-)
+	// deployments
+	Entry("deployments", "deployments", diagnose.Deployment),
+	Entry("deployment", "deployment", diagnose.Deployment),
+	Entry("deploy", "deploy", diagnose.Deployment),
+	Entry("deployment.apps", "deployment.apps", diagnose.Deployment),
 
-var _ = DescribeTable("pod kind",
-	func(kind string, expected bool) {
-		Expect(diagnose.IsPod(kind)).To(Equal(expected))
-	},
-	Entry("pod", "pod", true),
-	Entry("pods", "pods", true),
-	Entry("po", "po", true),
-	Entry("other", "other", false),
+	// pods
+	Entry("pods", "pods", diagnose.Pod),
+	Entry("pod", "pod", diagnose.Pod),
+	Entry("po", "po", diagnose.Pod),
+
+	// statefulsets
+	Entry("statefulsets", "statefulsets", diagnose.StatefulSet),
+	Entry("statefulset", "statefulset", diagnose.StatefulSet),
+	Entry("sts", "sts", diagnose.StatefulSet),
+	Entry("statefulset.apps", "statefulset.apps", diagnose.StatefulSet),
+
+	// persistent volume claims
+	Entry("persistentvolumeclaims", "persistentvolumeclaims", diagnose.PersistentVolumeClaim),
+	Entry("persistentvolumeclaim", "persistentvolumeclaim", diagnose.PersistentVolumeClaim),
+	Entry("pvc", "pvc", diagnose.PersistentVolumeClaim),
+
+	// storage classe
+	Entry("storageclass", "storageclass", diagnose.StorageClass),
+	Entry("storageclasses", "storageclasses", diagnose.StorageClass),
+	Entry("sc", "sc", diagnose.StorageClass),
+	Entry("storageclass.storage.k8s.io", "storageclass.storage.k8s.io", diagnose.StorageClass),
+	// unknown
+	Entry("other", "other", diagnose.Unkwown),
 )


### PR DESCRIPTION
use a single 'switch/case' block instead of multiple funcs

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
