### PR TITLE
refactor(examples/test): update securityContext

### DIFF
--- a/examples/deployment-all-good.yaml
+++ b/examples/deployment-all-good.yaml
@@ -62,15 +62,16 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
+        allowPrivilegeEscalation: false
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/deployment-pod-crash-loop-back-off.yaml
+++ b/examples/deployment-pod-crash-loop-back-off.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true # but caddy needs to run as `root` to listen on port 80
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true # but caddy needs to run as `root` to listen on port 80
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/deployment-pod-image-pull-back-off.yaml
+++ b/examples/deployment-pod-image-pull-back-off.yaml
@@ -62,9 +62,9 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true # but caddy process needs to run as root for port 80
       securityContext:
-        runAsNonRoot: true # but caddy process needs to run as root for port 80
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default

--- a/examples/deployment-pod-readiness-probe-error.yaml
+++ b/examples/deployment-pod-readiness-probe-error.yaml
@@ -68,15 +68,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/deployment-pod-unknown-configmap.yaml
+++ b/examples/deployment-pod-unknown-configmap.yaml
@@ -68,15 +68,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/deployment-service-account-not-found.yaml
+++ b/examples/deployment-service-account-not-found.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: deploy-sa-notfound # ServiceAccount does not exist (by default, only `default` exists)
       serviceAccountName: deploy-sa-notfound 
       volumes:

--- a/examples/deployment-zero-replica.yaml
+++ b/examples/deployment-zero-replica.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/route-invalid-target-port-int.yaml
+++ b/examples/route-invalid-target-port-int.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/route-invalid-target-port-str.yaml
+++ b/examples/route-invalid-target-port-str.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/route-unknown-target-service.yaml
+++ b/examples/route-unknown-target-service.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/service-invalid-target-port-int.yaml
+++ b/examples/service-invalid-target-port-int.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/service-invalid-target-port-str.yaml
+++ b/examples/service-invalid-target-port-str.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/service-no-matching-pods.yaml
+++ b/examples/service-no-matching-pods.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/statefulset-all-good.yaml
+++ b/examples/statefulset-all-good.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/statefulset-invalid-storageclass.yaml
+++ b/examples/statefulset-invalid-storageclass.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/statefulset-pod-unknown-configmap.yaml
+++ b/examples/statefulset-pod-unknown-configmap.yaml
@@ -68,15 +68,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/examples/statefulset-service-account-not-found.yaml
+++ b/examples/statefulset-service-account-not-found.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: unknown # invalid
       serviceAccountName: unknown
       volumes:

--- a/examples/statefulset-zero-replica.yaml
+++ b/examples/statefulset-zero-replica.yaml
@@ -62,15 +62,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - name: caddy-config
           mountPath: "/etc/caddy"
         - name: caddy-config-cache
           mountPath: "/config/caddy"
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/testsupport/resources/all-good.yaml
+++ b/testsupport/resources/all-good.yaml
@@ -81,15 +81,15 @@ spec:
       requests:
         cpu: 100m
         memory: 20Mi
+    securityContext:
+      runAsNonRoot: true
     volumeMounts:
     - name: caddy-config
       mountPath: "/etc/caddy"
     - name: caddy-config-cache
       mountPath: "/config/caddy"
   securityContext:
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
+    runAsUser: 1003870000
   serviceAccount: default
   serviceAccountName: default
   volumes:
@@ -139,15 +139,17 @@ spec:
       requests:
         cpu: 100m
         memory: 20Mi
+    securityContext:
+      runAsNonRoot: true
     volumeMounts:
     - name: caddy-config
       mountPath: "/etc/caddy"
     - name: caddy-config-cache
       mountPath: "/config/caddy"
-  securityContext:
-    runAsNonRoot: true
     seccompProfile:
       type: RuntimeDefault
+  securityContext:
+    runAsUser: 1003870000
   serviceAccount: default
   serviceAccountName: default
   volumes:

--- a/testsupport/resources/deployment-pod-crash-loop-back-off.yaml
+++ b/testsupport/resources/deployment-pod-crash-loop-back-off.yaml
@@ -68,15 +68,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
         - mountPath: /config/caddy
           name: caddy-config-cache
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       volumes:
       - configMap:
@@ -144,6 +144,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -153,9 +155,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       volumes:
       - configMap:

--- a/testsupport/resources/deployment-pod-image-pull-back-off.yaml
+++ b/testsupport/resources/deployment-pod-image-pull-back-off.yaml
@@ -77,10 +77,10 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
 status:
@@ -138,10 +138,10 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
 status:

--- a/testsupport/resources/deployment-pod-readiness-probe-error.yaml
+++ b/testsupport/resources/deployment-pod-readiness-probe-error.yaml
@@ -71,6 +71,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -80,9 +82,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:
@@ -157,15 +157,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
         - mountPath: /config/caddy
           name: caddy-config-cache
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/testsupport/resources/deployment-pod-unknown-configmap.yaml
+++ b/testsupport/resources/deployment-pod-unknown-configmap.yaml
@@ -77,15 +77,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
         - mountPath: /config/caddy
           name: caddy-config-cache
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
@@ -153,15 +153,15 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
         - mountPath: /config/caddy
           name: caddy-config-cache
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       volumes:

--- a/testsupport/resources/deployment-service-account-not-found.yaml
+++ b/testsupport/resources/deployment-service-account-not-found.yaml
@@ -88,6 +88,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -97,9 +99,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: deploy-sa-notfound
       serviceAccountName: deploy-sa-notfound
       terminationGracePeriodSeconds: 30
@@ -173,6 +173,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -182,9 +184,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: deploy-sa-notfound
       serviceAccountName: deploy-sa-notfound
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/deployment-zero-replica.yaml
+++ b/testsupport/resources/deployment-zero-replica.yaml
@@ -88,6 +88,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -97,9 +99,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
@@ -173,6 +173,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -182,9 +184,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/fake-api-server.yaml
+++ b/testsupport/resources/fake-api-server.yaml
@@ -81,15 +81,15 @@ spec:
       requests:
         cpu: 100m
         memory: 20Mi
+    securityContext:
+      runAsNonRoot: true
     volumeMounts:
     - name: caddy-config
       mountPath: "/etc/caddy"
     - name: caddy-config-cache
       mountPath: "/config/caddy"
   securityContext:
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
+    runAsUser: 1003870000
   serviceAccount: default
   serviceAccountName: default
   volumes:
@@ -139,15 +139,15 @@ spec:
       requests:
         cpu: 100m
         memory: 20Mi
+    securityContext:
+      runAsNonRoot: true
     volumeMounts:
     - name: caddy-config
       mountPath: "/etc/caddy"
     - name: caddy-config-cache
       mountPath: "/config/caddy"
   securityContext:
-    runAsNonRoot: true
-    seccompProfile:
-      type: RuntimeDefault
+    runAsUser: 1003870000
   serviceAccount: default
   serviceAccountName: default
   volumes:
@@ -279,6 +279,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -288,9 +290,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
@@ -370,6 +370,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -379,9 +381,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: unknown
       serviceAccountName: unknown
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/route-invalid-target-port-int.yaml
+++ b/testsupport/resources/route-invalid-target-port-int.yaml
@@ -71,6 +71,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -80,9 +82,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
@@ -155,6 +155,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -164,9 +166,8 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
+      type: RuntimeDefault
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/route-invalid-target-port-str.yaml
+++ b/testsupport/resources/route-invalid-target-port-str.yaml
@@ -68,6 +68,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -77,9 +79,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
@@ -152,6 +152,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -161,9 +163,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/route-unknown-target-service.yaml
+++ b/testsupport/resources/route-unknown-target-service.yaml
@@ -87,6 +87,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -96,9 +98,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
@@ -170,6 +170,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -179,9 +181,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/service-invalid-target-port-int.yaml
+++ b/testsupport/resources/service-invalid-target-port-int.yaml
@@ -88,6 +88,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -97,9 +99,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
@@ -171,6 +171,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -180,9 +182,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/service-invalid-target-port-str.yaml
+++ b/testsupport/resources/service-invalid-target-port-str.yaml
@@ -87,6 +87,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -96,9 +98,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
@@ -168,6 +168,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -177,9 +179,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/service-no-matching-pods.yaml
+++ b/testsupport/resources/service-no-matching-pods.yaml
@@ -91,6 +91,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -100,9 +102,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30
@@ -172,6 +172,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -183,9 +185,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/statefulset-invalid-storageclass.yaml
+++ b/testsupport/resources/statefulset-invalid-storageclass.yaml
@@ -89,6 +89,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -98,9 +100,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/statefulset-pod-unknown-configmap.yaml
+++ b/testsupport/resources/statefulset-pod-unknown-configmap.yaml
@@ -96,6 +96,8 @@ spec:
           requests:
             cpu: 100m
             memory: 20Mi
+        securityContext:
+          runAsNonRoot: true
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
         volumeMounts:
@@ -107,9 +109,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/statefulset-service-account-not-found.yaml
+++ b/testsupport/resources/statefulset-service-account-not-found.yaml
@@ -88,6 +88,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -97,9 +99,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: unknown
       serviceAccountName: unknown
       terminationGracePeriodSeconds: 30

--- a/testsupport/resources/statefulset-zero-replica.yaml
+++ b/testsupport/resources/statefulset-zero-replica.yaml
@@ -89,6 +89,8 @@ spec:
             memory: 20Mi
         terminationMessagePath: /dev/termination-log
         terminationMessagePolicy: File
+        securityContext:
+          runAsNonRoot: true
         volumeMounts:
         - mountPath: /etc/caddy
           name: caddy-config
@@ -98,9 +100,7 @@ spec:
       restartPolicy: Always
       schedulerName: default-scheduler
       securityContext:
-        runAsNonRoot: true
-        seccompProfile:
-          type: RuntimeDefault
+        runAsUser: 1003870000
       serviceAccount: default
       serviceAccountName: default
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
set 'runAsNonRoot: true' at container level and 'runAsUser: 1003870000' at pod level

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
