### PR TITLE
refactor(logger): test logger with '--loglevel' flag support

### DIFF
--- a/cmd/diagnose_cmd.go
+++ b/cmd/diagnose_cmd.go
@@ -27,7 +27,7 @@ func NewDiagnoseCmd() *cobra.Command {
 
 	var kubeconfig string
 	var namespace string
-	var loglevel int
+	var loglevel string
 
 	cmd := &cobra.Command{
 		Use:           "kubectl-diagnose (TYPE NAME | TYPE/NAME)",
@@ -37,8 +37,11 @@ func NewDiagnoseCmd() *cobra.Command {
 		Args:          cobra.RangeArgs(1, 2),
 		Version:       version(),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			logger := logr.New(cmd.OutOrStdout())
-			logger.SetLevel(loglevel)
+			l, err := logr.ParseLevel(loglevel)
+			if err != nil {
+				return err
+			}
+			logger := logr.New(cmd.OutOrStdout(), l)
 			kind, name, err := getResourceTypeName(args)
 			if err != nil {
 				return err
@@ -70,7 +73,7 @@ func NewDiagnoseCmd() *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&kubeconfig, "kubeconfig", "", "", "(optional) absolute path to the kubeconfig file")
 	cmd.Flags().StringVarP(&namespace, "namespace", "n", "", "(optional) the namespace scope for this CLI request")
-	cmd.Flags().IntVarP(&loglevel, "loglevel", "v", 0, "log level for V logs (set to 1 or higher to display DEBUG messages)")
+	cmd.Flags().StringVar(&loglevel, "loglevel", "info", "log level to set [debug|info|error|]")
 
 	return cmd
 }

--- a/pkg/diagnose/diagnose_test.go
+++ b/pkg/diagnose/diagnose_test.go
@@ -3,12 +3,10 @@ package diagnose_test
 import (
 	"errors"
 	"fmt"
-	"io"
 	"net/http"
 	"time"
 
 	"github.com/xcoulon/kubectl-diagnose/pkg/diagnose"
-	"github.com/xcoulon/kubectl-diagnose/pkg/logr"
 	"github.com/xcoulon/kubectl-diagnose/testsupport"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -23,7 +21,7 @@ import (
 var _ = DescribeTable("should detect missing route target service",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/route-unknown-target-service.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -43,7 +41,7 @@ var _ = DescribeTable("should detect missing route target service",
 var _ = DescribeTable("should detect invalid route target port as string",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/route-invalid-target-port-str.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -63,7 +61,7 @@ var _ = DescribeTable("should detect invalid route target port as string",
 var _ = DescribeTable("should detect invalid route target port as int",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/route-invalid-target-port-int.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -86,7 +84,7 @@ var _ = DescribeTable("should detect invalid route target port as int",
 var _ = DescribeTable("should detect missing target service",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/ingress-unknown-target-service.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -106,7 +104,7 @@ var _ = DescribeTable("should detect missing target service",
 var _ = DescribeTable("should detect invalid service port",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/ingress-invalid-service-port.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -126,7 +124,7 @@ var _ = DescribeTable("should detect invalid service port",
 var _ = DescribeTable("should detect invalid service name",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/ingress-invalid-service-name.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -146,7 +144,7 @@ var _ = DescribeTable("should detect invalid service name",
 var _ = DescribeTable("should detect invalid ingressclassname",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/ingress-invalid-ingressclassname.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -166,7 +164,7 @@ var _ = DescribeTable("should detect invalid ingressclassname",
 var _ = DescribeTable("should not fail when get ingressclass is forbidden", // ingressclasses are cluster-scoped resources and user may not be allowed to get/list such resources
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/ingress-forbidden-ingressclassname.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -191,7 +189,7 @@ var _ = DescribeTable("should not fail when get ingressclass is forbidden", // i
 var _ = DescribeTable("should detect no matching pods",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/service-no-matching-pods.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -217,7 +215,7 @@ var _ = DescribeTable("should detect no matching pods",
 var _ = DescribeTable("should detect invalid service target port as string",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/service-invalid-target-port-str.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -242,7 +240,7 @@ var _ = DescribeTable("should detect invalid service target port as string",
 var _ = DescribeTable("should detect invalid service target port as int",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/service-invalid-target-port-int.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -270,7 +268,7 @@ var _ = DescribeTable("should detect invalid service target port as int",
 var _ = DescribeTable("should detect zero replicas specified in deployment",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/deployment-zero-replica.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -304,7 +302,7 @@ var _ = DescribeTable("should detect zero replicas specified in deployment",
 var _ = DescribeTable("should detect invalid serviceaccount specified in deployment",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/deployment-service-account-not-found.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -341,7 +339,7 @@ var _ = DescribeTable("should detect invalid serviceaccount specified in deploym
 var _ = DescribeTable("should detect zero replicas specified in deployment",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/statefulset-zero-replica.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -374,7 +372,7 @@ var _ = DescribeTable("should detect zero replicas specified in deployment",
 var _ = DescribeTable("should detect invalid serviceaccount specified in statefulset",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/statefulset-service-account-not-found.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -407,7 +405,7 @@ var _ = DescribeTable("should detect invalid serviceaccount specified in statefu
 var _ = DescribeTable("should detect invalid storageclass specified in statefulset",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/statefulset-invalid-storageclass.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -448,7 +446,7 @@ var _ = DescribeTable("should detect invalid storageclass specified in statefuls
 var _ = DescribeTable("should detect deployment pod container in CrashLoopBackOff status",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/deployment-pod-crash-loop-back-off.yaml", "resources/deployment-pod-crash-loop-back-off.logs")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -488,7 +486,7 @@ var _ = DescribeTable("should detect deployment pod container in CrashLoopBackOf
 var _ = DescribeTable("should detect deployment pod container in ImagePullBackOff status",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/deployment-pod-image-pull-back-off.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -526,7 +524,7 @@ var _ = DescribeTable("should detect deployment pod container in ImagePullBackOf
 var _ = DescribeTable("should detect deployment pod container with readiness probe error",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/deployment-pod-readiness-probe-error.yaml", "resources/deployment-pod-readiness-probe-error.logs")
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -567,7 +565,7 @@ var _ = DescribeTable("should detect deployment pod container with readiness pro
 var _ = DescribeTable("should detect deployment pod container with unknown configmap mount",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/deployment-pod-unknown-configmap.yaml") // no logs, container is not created
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -608,7 +606,7 @@ var _ = DescribeTable("should detect deployment pod container with unknown confi
 var _ = DescribeTable("should detect statefulset pod container with unknown configmap mount",
 	func(kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger, "resources/statefulset-pod-unknown-configmap.yaml") // no logs, container is not created
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -648,7 +646,7 @@ var _ = DescribeTable("should detect statefulset pod container with unknown conf
 var _ = DescribeTable("should handle internal server errors",
 	func(gr string, kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger)
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")
@@ -670,7 +668,7 @@ var _ = DescribeTable("should handle internal server errors",
 var _ = DescribeTable("should handle not found errors",
 	func(gr string, kind diagnose.ResourceKind, namespace, name string) {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		apiserver, err := testsupport.NewFakeAPIServer(logger)
 		Expect(err).NotTo(HaveOccurred())
 		cfg := testsupport.NewConfig(apiserver.URL, "/api")

--- a/testsupport/fake_api_server_test.go
+++ b/testsupport/fake_api_server_test.go
@@ -1,12 +1,9 @@
 package testsupport_test
 
 import (
-	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 
-	"github.com/xcoulon/kubectl-diagnose/pkg/logr"
 	"github.com/xcoulon/kubectl-diagnose/testsupport"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -25,7 +22,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get single pod", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -40,7 +37,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get no pod", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -55,7 +52,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should fail to get single pod", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -70,7 +67,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should list 2 pods", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -85,7 +82,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should list no pod", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -100,7 +97,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get single replicaset", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/deployment-service-account-not-found.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -115,7 +112,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get no replicaset", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -130,7 +127,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should fail to get single replicaset", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -145,7 +142,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should list 2 replicasets", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -160,7 +157,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should list 1 replicaset by labelSelector", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -175,7 +172,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should list 2 replicasets by labelSelector", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -190,7 +187,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should list 2 statefulsets", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -205,7 +202,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should list 1 replicaset by labelSelector", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -220,7 +217,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get single deployment", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/deployment-service-account-not-found.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -235,7 +232,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get no deployment", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -250,7 +247,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should fail to get single deployment", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -265,7 +262,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get single service", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -280,7 +277,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get no service", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -295,7 +292,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should fail to get single service", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -310,7 +307,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get single route", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -325,7 +322,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get no route", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -340,7 +337,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should fail to get single route", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -355,7 +352,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get single ingress", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -370,7 +367,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get no ingress", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -385,7 +382,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should fail to get single ingress", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -400,7 +397,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get single ingressclass", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -415,7 +412,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get no ingressclass", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -430,7 +427,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should fail to get single ingressclass", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -445,7 +442,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should list 1 event by fieldSelector", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -460,7 +457,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should list no events by fieldSelector", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -475,7 +472,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should retrieve logs", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml", "resources/all-good.logs")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -490,7 +487,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should not match any endpoint", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger)
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -505,7 +502,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get single pvc", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -520,7 +517,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should get no pvc", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -535,7 +532,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should fail to get single pvc", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -550,7 +547,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should list 1 pvc per label selector", func() {
 		// given
-		logger := logr.New(io.Discard)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()
@@ -565,8 +562,7 @@ var _ = Describe("fake api-server endpoints", func() {
 
 	It("should list 1 pvc per label selector", func() {
 		// given
-		logger := logr.New(os.Stdout)
-		logger.SetLevel(logr.DebugLevel)
+		logger := testsupport.NewLogger()
 		s, err := testsupport.NewFakeAPIServer(logger, "resources/fake-api-server.yaml")
 		Expect(err).NotTo(HaveOccurred())
 		defer s.Close()

--- a/testsupport/logger.go
+++ b/testsupport/logger.go
@@ -1,0 +1,40 @@
+package testsupport
+
+import (
+	"bytes"
+	"flag"
+	"io"
+	"os"
+
+	"github.com/xcoulon/kubectl-diagnose/pkg/logr"
+)
+
+var logLevel string
+
+func init() {
+	flag.StringVar(&logLevel, "loglevel", "info", "log level to set [debug|info|error|]")
+}
+
+func NewLogger() *TestLogger {
+	buff := bytes.NewBuffer(nil)
+	switch logLevel {
+	case "debug":
+		return &TestLogger{
+			Logger: logr.New(io.MultiWriter(os.Stdout, buff), logr.DebugLevel),
+			buff:   buff,
+		}
+	}
+	return &TestLogger{
+		Logger: logr.New(io.MultiWriter(io.Discard, buff), logr.InfoLevel),
+		buff:   buff,
+	}
+}
+
+type TestLogger struct {
+	logr.Logger
+	buff *bytes.Buffer
+}
+
+func (l *TestLogger) Output() string {
+	return l.buff.String()
+}


### PR DESCRIPTION
append '-- --loglevel=debug' in CLI to get log outputs in the console (in debug mode)

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
