### PR TITLE
fix(diagnose): do not filter events on resource version

### DIFF
--- a/cmd/diagnose_cmd.go
+++ b/cmd/diagnose_cmd.go
@@ -31,7 +31,7 @@ func NewDiagnoseCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:           "kubectl-diagnose (TYPE NAME | TYPE/NAME)",
-		Short:         "try to find the cause of the 503 error",
+		Short:         "Diagnose the resource to find the cause of the 503 error",
 		SilenceErrors: false,
 		SilenceUsage:  false,
 		Args:          cobra.RangeArgs(1, 2),

--- a/pkg/diagnose/events.go
+++ b/pkg/diagnose/events.go
@@ -16,7 +16,7 @@ import (
 func checkEvents(logger logr.Logger, cl *kubernetes.Clientset, obj runtimeclient.Object) (bool, error) {
 	logger.Debugf("👀 checking events...")
 	events, err := cl.CoreV1().Events(obj.GetNamespace()).List(context.TODO(), metav1.ListOptions{
-		FieldSelector: fmt.Sprintf("type=Warning,involvedObject.uid=%s,involvedObject.resourceVersion=%s", obj.GetUID(), obj.GetResourceVersion()),
+		FieldSelector: fmt.Sprintf("type=Warning,involvedObject.uid=%s", obj.GetUID()),
 	})
 	if err != nil {
 		return false, err

--- a/testsupport/resources/deployment-pod-crash-loop-back-off.yaml
+++ b/testsupport/resources/deployment-pod-crash-loop-back-off.yaml
@@ -275,11 +275,12 @@ data:
 
     respond "Everything is fine!"
 ---
+# unreleated event
 apiVersion: v1
 kind: Event
 metadata:
   namespace: test
-  name: deploy-crash-loop-back-off.17233cf30d5bf54b
+  name: unrelated.17233cf30d5bf54b
 count: 4
 type: Warning
 reason: BackOff
@@ -290,7 +291,7 @@ involvedObject:
   apiVersion: v1
   kind: Pod
   namespace: test
-  name: deploy-crash-loop-back-off
+  name: unrelated 
   resourceVersion: "277004"
 ---
 apiVersion: v1
@@ -309,5 +310,5 @@ involvedObject:
   kind: Pod
   namespace: test
   name: deploy-crash-loop-back-off-7994787459-2nrz5
-  resourceVersion: "277004"
+  resourceVersion: "277000" # older version
   uid: 6097891a-2ea8-4f56-9f4b-8627474612b2


### PR DESCRIPTION
this is too restrictive: resource version changes when resource status is updated, but events associated with previous version may still be relevant

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
