### PR TITLE
feat(diagnose): detect TLS misconfiguration

### DIFF
--- a/pkg/diagnose/diagnose.go
+++ b/pkg/diagnose/diagnose.go
@@ -41,6 +41,7 @@ func diagnose(ctx context.Context, logger *charmlog.Logger, cfg *rest.Config, ki
 
 const NotFoundMsg = `🤷 couldn't find the culprit
 💡 possible causes:
+   - missing TLS annotations on a route or a service?
    - invalid configuration of a container within the pod?
    - trying to connect to a container listening to '127.0.0.1' instead of '0.0.0.0'?
    - redirecting to an invalid callback URL after logging in on a third-party SSO?

--- a/pkg/diagnose/diagnose_test.go
+++ b/pkg/diagnose/diagnose_test.go
@@ -697,7 +697,8 @@ func TestDiagnose(t *testing.T) {
 				},
 				expectedFound: true,
 				expectedMsgs: []string{
-					`TLS handshake error`,
+					`tls: bad record MAC`,
+					`wrong TLS secret mounted on the 'oauth2-proxy' container?`,
 				},
 			},
 		},
@@ -723,11 +724,6 @@ func TestDiagnose(t *testing.T) {
 						namespace: "test",
 						name:      "all-good-785d8bcc5f",
 					},
-					// {
-					// 	kind:      diagnose.Deployment,
-					// 	namespace: "test",
-					// 	name:      "all-good",
-					// },
 					{
 						kind:      diagnose.Service,
 						namespace: "test",


### PR DESCRIPTION
happens when oaiuth2-proxy container has the wrong TLS secret mounted as a volume

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
