### PR TITLE
feat(diagnose): one more clue

### DIFF
--- a/pkg/diagnose/diagnose.go
+++ b/pkg/diagnose/diagnose.go
@@ -43,6 +43,7 @@ const NotFoundMsg = `🤷 couldn't find the culprit
 💡 possible causes:
    - missing TLS annotations on a route or a service?
    - invalid configuration of a container within the pod?
+   - mismatch in container's exposed port vs listening port?
    - trying to connect to a container listening to '127.0.0.1' instead of '0.0.0.0'?
    - redirecting to an invalid callback URL after logging in on a third-party SSO?
    - something else?`


### PR DESCRIPTION
in case no obvious problem found:
a container may be running a process listening on
a port that doesn't match any of its defined ports

Signed-off-by: Xavier Coulon <xcoulon@redhat.com>
